### PR TITLE
Add GCP Workload Identity Federation auth step to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,6 +53,12 @@ jobs:
       - name: Install dependencies
         run: uv sync
 
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
       - name: Generate website
         run: uv run build.py
 


### PR DESCRIPTION
Authenticates to GCP via WIF before the build step, enabling keyless access to GCS without long-lived service account keys.

Fixes #35, prerequisite for #36.