### PR TITLE
Read changelog from changes.json with a recent-history "What's new" panel

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -173,6 +173,42 @@
     .songbook-changelog li:last-child {
       border-bottom: none;
     }
+    .songbook-changelog .changelog-date {
+      margin-top: 0.4em;
+      font-weight: bold;
+      color: #333;
+    }
+    .songbook-changelog .changelog-earlier {
+      margin-top: 0.8em;
+      border-top: 1px solid #eee;
+      padding-top: 0.4em;
+    }
+    .songbook-changelog .changelog-earlier > summary {
+      cursor: pointer;
+      padding: 0.2em 0;
+      font-weight: normal;
+      color: #777;
+      font-size: 0.95em;
+      list-style-position: inside;
+    }
+    .songbook-changelog .changelog-earlier > summary:hover {
+      color: var(--primary-color);
+    }
+    .songbook-changelog .changelog-earlier-list {
+      margin-top: 0.3em;
+    }
+    .songbook-changelog .changelog-earlier-list li {
+      display: flex;
+      justify-content: space-between;
+      gap: 0.5em;
+    }
+    .songbook-changelog .changelog-earlier-date {
+      color: #555;
+    }
+    .songbook-changelog .changelog-earlier-counts {
+      color: #888;
+      white-space: nowrap;
+    }
     footer {
       margin-top: 2em;
       padding: 1.5em 1em;

--- a/assets/style.css
+++ b/assets/style.css
@@ -144,7 +144,7 @@
     }
     .songbook-changelog .changelog-body {
       padding: 0 1em 0.8em;
-      max-height: 16em;
+      max-height: 20em;
       overflow-y: auto;
     }
     .songbook-changelog .changelog-group {
@@ -178,36 +178,24 @@
       font-weight: bold;
       color: #333;
     }
-    .songbook-changelog .changelog-earlier {
+    .songbook-changelog .changelog-more {
       margin-top: 0.8em;
-      border-top: 1px solid #eee;
-      padding-top: 0.4em;
-    }
-    .songbook-changelog .changelog-earlier > summary {
-      cursor: pointer;
       padding: 0.2em 0;
-      font-weight: normal;
-      color: #777;
-      font-size: 0.95em;
-      list-style-position: inside;
-    }
-    .songbook-changelog .changelog-earlier > summary:hover {
+      background: none;
+      border: none;
+      font: inherit;
+      font-weight: bold;
       color: var(--primary-color);
+      cursor: pointer;
     }
-    .songbook-changelog .changelog-earlier-list {
-      margin-top: 0.3em;
+    .songbook-changelog .changelog-more:hover {
+      color: #0b6b63;
+      text-decoration: underline;
     }
-    .songbook-changelog .changelog-earlier-list li {
-      display: flex;
-      justify-content: space-between;
-      gap: 0.5em;
-    }
-    .songbook-changelog .changelog-earlier-date {
-      color: #555;
-    }
-    .songbook-changelog .changelog-earlier-counts {
-      color: #888;
-      white-space: nowrap;
+    .songbook-changelog .changelog-earlier .changelog-entry {
+      margin-top: 0.6em;
+      padding-top: 0.6em;
+      border-top: 1px solid #eee;
     }
     footer {
       margin-top: 2em;

--- a/build.py
+++ b/build.py
@@ -19,6 +19,9 @@ PREVIEW_DIR = os.path.join(OUTPUT_DIR, 'previews')
 TEMPLATE_DIR = 'templates'
 TEMPLATE_FILE = 'index.html.j2'
 EDITIONS_FILE = 'editions.yml'
+# Number of older changelog entries to list under the latest change in the
+# "What's new" panel (the most recent change is always shown in full).
+CHANGELOG_HISTORY_LIMIT = 10
 
 def create_session_with_retry(max_retries=5, backoff_factor=1):
     """
@@ -96,22 +99,81 @@ def get_edition_manifest(bucket, edition_name, manifest_filename):
         print(f"  Could not fetch or parse manifest {blob_name}: {e}")
         return None
 
-def extract_changelog(manifest):
-    """Extracts the added/removed song lists from a manifest's changelog object.
+def get_edition_changes(bucket, edition_name):
+    """Fetches and parses an edition's changes.json.
 
-    Returns a dict with 'added' and 'removed' lists, or None if the manifest has
-    no changelog or the changelog has no additions or removals.
+    changes.json is the append-only changelog history maintained by the
+    songbook-generator: a dict with an 'entries' list ordered newest-first,
+    each entry describing the songs added/removed in a publish.
     """
-    if not manifest:
+    blob_name = f"{edition_name}/changes.json"
+    blob = bucket.blob(blob_name)
+    try:
+        changes_url = f"https://storage.googleapis.com/{bucket.name}/{blob_name}"
+        print(f"  Fetching changes from: {changes_url}")
+        data = blob.download_as_text()
+        return json.loads(data)
+    except Exception as e:
+        print(f"  Could not fetch or parse changes {blob_name}: {e}")
         return None
-    changelog = manifest.get('changelog')
-    if not changelog:
+
+def format_changelog_date(generated_at):
+    """Formats an ISO 8601 timestamp into a short date like '9 Jun 2026'.
+
+    Returns an empty string if the timestamp is missing or unparseable.
+    """
+    if not generated_at:
+        return ''
+    try:
+        dt = datetime.fromisoformat(generated_at.replace('Z', '+00:00'))
+    except (ValueError, AttributeError):
+        return ''
+    return f"{dt.day} {dt:%b %Y}"
+
+def build_changelog(changes, history_limit=CHANGELOG_HISTORY_LIMIT):
+    """Builds the "What's new" panel data from an edition's changes.json.
+
+    Surfaces the most recent change in full (date plus the songs added/removed)
+    followed by a short, dated history of earlier changes (counts only). The
+    'entries' in `changes` are expected newest-first, as published by the
+    generator.
+
+    Returns a dict shaped like::
+
+        {
+            'latest': {'date': '9 Jun 2026', 'added': [...], 'removed': [...]},
+            'earlier': [{'date': '2 Jun 2026', 'added_count': 3, 'removed_count': 3}, ...],
+        }
+
+    or None when there are no entries with any additions or removals.
+    """
+    if not changes:
         return None
-    added = changelog.get('added', [])
-    removed = changelog.get('removed', [])
-    if not added and not removed:
+
+    entries = [
+        entry for entry in changes.get('entries', [])
+        if entry.get('added') or entry.get('removed')
+    ]
+    if not entries:
         return None
-    return {'added': added, 'removed': removed}
+
+    latest = entries[0]
+    latest_data = {
+        'date': format_changelog_date(latest.get('generated_at')),
+        'added': latest.get('added', []),
+        'removed': latest.get('removed', []),
+    }
+
+    earlier = [
+        {
+            'date': format_changelog_date(entry.get('generated_at')),
+            'added_count': entry.get('added_count', len(entry.get('added', []))),
+            'removed_count': entry.get('removed_count', len(entry.get('removed', []))),
+        }
+        for entry in entries[1:1 + history_limit]
+    ]
+
+    return {'latest': latest_data, 'earlier': earlier}
 
 def get_buymeacoffee_stats():
     """Fetch supporter statistics from Buy Me a Coffee API with pagination."""
@@ -387,10 +449,12 @@ if __name__ == '__main__':
             continue
 
         changelog = None
+        if show_changelog:
+            changes = get_edition_changes(bucket, edition_name)
+            changelog = build_changelog(changes)
+
         if 'manifest_filename' in latest_info:
             manifest = get_edition_manifest(bucket, edition_name, latest_info['manifest_filename'])
-            if show_changelog:
-                changelog = extract_changelog(manifest)
             if manifest and 'generated_at' in manifest:
                 generated_at_str = manifest['generated_at']
                 try:

--- a/build.py
+++ b/build.py
@@ -130,11 +130,20 @@ def format_changelog_date(generated_at):
         return ''
     return f"{dt.day} {dt:%b %Y}"
 
+def _changelog_entry(entry):
+    """Shapes one changes.json entry for display: a date plus the song lists
+    added and removed."""
+    return {
+        'date': format_changelog_date(entry.get('generated_at')),
+        'added': entry.get('added', []),
+        'removed': entry.get('removed', []),
+    }
+
 def build_changelog(changes, history_limit=CHANGELOG_HISTORY_LIMIT):
     """Builds the "What's new" panel data from an edition's changes.json.
 
-    Surfaces the most recent change in full (date plus the songs added/removed)
-    followed by a short, dated history of earlier changes (counts only). The
+    Surfaces the most recent change followed by a short history of earlier
+    changes, each shaped identically (a date plus the songs added/removed). The
     'entries' in `changes` are expected newest-first, as published by the
     generator.
 
@@ -142,7 +151,7 @@ def build_changelog(changes, history_limit=CHANGELOG_HISTORY_LIMIT):
 
         {
             'latest': {'date': '9 Jun 2026', 'added': [...], 'removed': [...]},
-            'earlier': [{'date': '2 Jun 2026', 'added_count': 3, 'removed_count': 3}, ...],
+            'earlier': [{'date': '2 Jun 2026', 'added': [...], 'removed': [...]}, ...],
         }
 
     or None when there are no entries with any additions or removals.
@@ -157,23 +166,10 @@ def build_changelog(changes, history_limit=CHANGELOG_HISTORY_LIMIT):
     if not entries:
         return None
 
-    latest = entries[0]
-    latest_data = {
-        'date': format_changelog_date(latest.get('generated_at')),
-        'added': latest.get('added', []),
-        'removed': latest.get('removed', []),
+    return {
+        'latest': _changelog_entry(entries[0]),
+        'earlier': [_changelog_entry(entry) for entry in entries[1:1 + history_limit]],
     }
-
-    earlier = [
-        {
-            'date': format_changelog_date(entry.get('generated_at')),
-            'added_count': entry.get('added_count', len(entry.get('added', []))),
-            'removed_count': entry.get('removed_count', len(entry.get('removed', []))),
-        }
-        for entry in entries[1:1 + history_limit]
-    ]
-
-    return {'latest': latest_data, 'earlier': earlier}
 
 def get_buymeacoffee_stats():
     """Fetch supporter statistics from Buy Me a Coffee API with pagination."""

--- a/editions.yml
+++ b/editions.yml
@@ -3,8 +3,9 @@
 # Hidden editions are accessible at /<name>/ but not shown on the site listing.
 #
 # Optional 'show_changelog: true' surfaces a collapsible "What's new" panel on the
-# edition's card, listing the songs added/removed since the previous edition
-# (sourced from the 'changelog' object in the edition's manifest). Defaults to false.
+# edition's card, showing the most recent songs added/removed plus a short dated
+# history of earlier changes (sourced from the edition's 'changes.json'). Defaults
+# to false.
 #
 # Examples:
 #   - name: current        # displayed on site

--- a/templates/index.html.j2
+++ b/templates/index.html.j2
@@ -68,21 +68,42 @@
               {% endif %}
             </div>
           </a>
-          {% if file.changelog and (file.changelog.added or file.changelog.removed) %}
+          {% if file.changelog %}
+          {% set latest = file.changelog.latest %}
           <details class="songbook-changelog">
-            <summary>What's new ({{ file.changelog.added|length }} added, {{ file.changelog.removed|length }} removed)</summary>
+            <summary>What's new ({{ latest.added|length }} added, {{ latest.removed|length }} removed)</summary>
             <div class="changelog-body">
-              {% if file.changelog.added %}
-              <div class="changelog-group changelog-added">
-                <h4>Added</h4>
-                <ul>{% for song in file.changelog.added %}<li>{{ song }}</li>{% endfor %}</ul>
+              <div class="changelog-entry">
+                {% if latest.date %}<div class="changelog-date">{{ latest.date }}</div>{% endif %}
+                {% if latest.added %}
+                <div class="changelog-group changelog-added">
+                  <h4>Added</h4>
+                  <ul>{% for song in latest.added %}<li>{{ song }}</li>{% endfor %}</ul>
+                </div>
+                {% endif %}
+                {% if latest.removed %}
+                <div class="changelog-group changelog-removed">
+                  <h4>Removed</h4>
+                  <ul>{% for song in latest.removed %}<li>{{ song }}</li>{% endfor %}</ul>
+                </div>
+                {% endif %}
               </div>
-              {% endif %}
-              {% if file.changelog.removed %}
-              <div class="changelog-group changelog-removed">
-                <h4>Removed</h4>
-                <ul>{% for song in file.changelog.removed %}<li>{{ song }}</li>{% endfor %}</ul>
-              </div>
+              {% if file.changelog.earlier %}
+              <details class="changelog-earlier">
+                <summary>Earlier changes</summary>
+                <ul class="changelog-earlier-list">
+                {% for entry in file.changelog.earlier %}
+                  <li>
+                    <span class="changelog-earlier-date">{{ entry.date }}</span>
+                    <span class="changelog-earlier-counts">
+                      {%- if entry.added_count %}{{ entry.added_count }} added{% endif -%}
+                      {%- if entry.added_count and entry.removed_count %}, {% endif -%}
+                      {%- if entry.removed_count %}{{ entry.removed_count }} removed{% endif -%}
+                    </span>
+                  </li>
+                {% endfor %}
+                </ul>
+              </details>
               {% endif %}
             </div>
           </details>

--- a/templates/index.html.j2
+++ b/templates/index.html.j2
@@ -45,6 +45,23 @@
     </header>
     
     <main>
+      {% macro changelog_entry(entry) %}
+      <div class="changelog-entry">
+        {% if entry.date %}<div class="changelog-date">{{ entry.date }}</div>{% endif %}
+        {% if entry.added %}
+        <div class="changelog-group changelog-added">
+          <h4>Added</h4>
+          <ul>{% for song in entry.added %}<li>{{ song }}</li>{% endfor %}</ul>
+        </div>
+        {% endif %}
+        {% if entry.removed %}
+        <div class="changelog-group changelog-removed">
+          <h4>Removed</h4>
+          <ul>{% for song in entry.removed %}<li>{{ song }}</li>{% endfor %}</ul>
+        </div>
+        {% endif %}
+      </div>
+      {% endmacro %}
       <ul class="songbook-list">
       {% for file in files %}
         <li class="songbook-item">
@@ -69,41 +86,15 @@
             </div>
           </a>
           {% if file.changelog %}
-          {% set latest = file.changelog.latest %}
           <details class="songbook-changelog">
-            <summary>What's new ({{ latest.added|length }} added, {{ latest.removed|length }} removed)</summary>
+            <summary>What's new</summary>
             <div class="changelog-body">
-              <div class="changelog-entry">
-                {% if latest.date %}<div class="changelog-date">{{ latest.date }}</div>{% endif %}
-                {% if latest.added %}
-                <div class="changelog-group changelog-added">
-                  <h4>Added</h4>
-                  <ul>{% for song in latest.added %}<li>{{ song }}</li>{% endfor %}</ul>
-                </div>
-                {% endif %}
-                {% if latest.removed %}
-                <div class="changelog-group changelog-removed">
-                  <h4>Removed</h4>
-                  <ul>{% for song in latest.removed %}<li>{{ song }}</li>{% endfor %}</ul>
-                </div>
-                {% endif %}
-              </div>
+              {{ changelog_entry(file.changelog.latest) }}
               {% if file.changelog.earlier %}
-              <details class="changelog-earlier">
-                <summary>Earlier changes</summary>
-                <ul class="changelog-earlier-list">
-                {% for entry in file.changelog.earlier %}
-                  <li>
-                    <span class="changelog-earlier-date">{{ entry.date }}</span>
-                    <span class="changelog-earlier-counts">
-                      {%- if entry.added_count %}{{ entry.added_count }} added{% endif -%}
-                      {%- if entry.added_count and entry.removed_count %}, {% endif -%}
-                      {%- if entry.removed_count %}{{ entry.removed_count }} removed{% endif -%}
-                    </span>
-                  </li>
-                {% endfor %}
-                </ul>
-              </details>
+              <button type="button" class="changelog-more" hidden>Earlier changes…</button>
+              <div class="changelog-earlier">
+                {% for entry in file.changelog.earlier %}{{ changelog_entry(entry) }}{% endfor %}
+              </div>
               {% endif %}
             </div>
           </details>
@@ -188,6 +179,22 @@
             properties['songbook_subject'] = link.dataset.songbookSubject;
           }
           mixpanel.track('Songbook Download', properties);
+        });
+      });
+    });
+  </script>
+  <script>
+    // Progressive enhancement: without JS the earlier changelog entries are
+    // shown inline; with JS we tuck them behind an "Earlier changes…" button.
+    document.addEventListener('DOMContentLoaded', function() {
+      document.querySelectorAll('.changelog-more').forEach(function(btn) {
+        const earlier = btn.nextElementSibling;
+        if (!earlier) return;
+        earlier.hidden = true;
+        btn.hidden = false;
+        btn.addEventListener('click', function() {
+          earlier.hidden = false;
+          btn.hidden = true;
         });
       });
     });

--- a/test_build.py
+++ b/test_build.py
@@ -470,9 +470,13 @@ def test_build_changelog():
         'removed': ['Old Song - Artist C'],
     }
 
-    # Earlier changes are summarised (date + counts only).
+    # Earlier changes carry the same full shape (date + song lists) as the latest.
     assert result['earlier'] == [
-        {'date': '2 Jun 2026', 'added_count': 1, 'removed_count': 0},
+        {
+            'date': '2 Jun 2026',
+            'added': ['Hey Jude - The Beatles'],
+            'removed': [],
+        },
     ]
 
     # No changes -> None
@@ -480,20 +484,6 @@ def test_build_changelog():
     assert build_changelog({'edition': 'current', 'entries': []}) is None
     # Entries with no additions or removals are ignored.
     assert build_changelog({'entries': [{'added': [], 'removed': []}]}) is None
-
-
-def test_build_changelog_counts_fallback():
-    """Counts are derived from the song lists when not provided explicitly."""
-    changes = {
-        'entries': [
-            {'generated_at': '2026-06-09T00:00:00+00:00', 'added': ['A - B'], 'removed': []},
-            {'generated_at': '2026-06-02T00:00:00+00:00', 'added': ['C - D', 'E - F'], 'removed': ['G - H']},
-        ],
-    }
-    result = build_changelog(changes)
-    assert result['earlier'] == [
-        {'date': '2 Jun 2026', 'added_count': 2, 'removed_count': 1},
-    ]
 
 
 def test_build_changelog_history_limit():
@@ -528,7 +518,11 @@ def test_render_index_with_changelog(sample_supporter_stats):
                 'removed': ['Retired Song - Old Act'],
             },
             'earlier': [
-                {'date': '2 Jun 2026', 'added_count': 3, 'removed_count': 1},
+                {
+                    'date': '2 Jun 2026',
+                    'added': ['An Older Addition - Some Artist'],
+                    'removed': [],
+                },
             ],
         },
     }]
@@ -536,15 +530,18 @@ def test_render_index_with_changelog(sample_supporter_stats):
     html = render_index(files, supporter_stats=sample_supporter_stats)
 
     assert "What's new" in html
+    # The top summary no longer shows the (x added, x removed) counts.
+    assert "What's new (" not in html
     assert 'Added' in html
     assert 'Removed' in html
     assert 'Brand New Song - The Band' in html
     assert 'Retired Song - Old Act' in html
-    # The latest change is dated, and earlier changes are summarised.
     assert '9 Jun 2026' in html
+    # Earlier changes are revealed via a button and list their songs in full.
+    assert 'changelog-more' in html
     assert 'Earlier changes' in html
     assert '2 Jun 2026' in html
-    assert '3 added, 1 removed' in html
+    assert 'An Older Addition - Some Artist' in html
 
 
 def test_render_index_without_changelog(sample_files, sample_supporter_stats):

--- a/test_build.py
+++ b/test_build.py
@@ -10,7 +10,7 @@ import yaml
 from unittest.mock import MagicMock
 
 # Import functions from build.py for testing
-from build import get_buymeacoffee_stats, get_buymeacoffee_subscriptions, render_index, get_editions_config, get_latest_edition_info, get_edition_manifest, create_session_with_retry, extract_changelog
+from build import get_buymeacoffee_stats, get_buymeacoffee_subscriptions, render_index, get_editions_config, get_latest_edition_info, get_edition_manifest, create_session_with_retry, get_edition_changes, build_changelog, format_changelog_date
 
 
 @pytest.fixture
@@ -403,29 +403,114 @@ def test_render_index_with_monthly_supporters(sample_files, sample_supporter_sta
     assert 'Jane Smith' in html
     assert 'Bob Wilson' in html
 
-def test_extract_changelog():
-    """Test extracting added/removed songs from a manifest's changelog."""
-    # Manifest with a changelog containing additions and removals
-    manifest = {
-        'changelog': {
-            'added': ['New Song - Artist A', 'Another One - Artist B'],
-            'removed': ['Old Song - Artist C'],
-        }
+def test_get_edition_changes():
+    """Test fetching and parsing an edition's changes.json."""
+    mock_bucket = MagicMock()
+    mock_bucket.name = 'test-bucket'
+    mock_blob = MagicMock()
+
+    changes_content = json.dumps({
+        'edition': 'current',
+        'entries': [
+            {'generated_at': '2026-06-09T10:48:10+00:00', 'added': ['A - B'], 'removed': []},
+        ],
+    })
+    mock_blob.download_as_text.return_value = changes_content
+    mock_bucket.blob.return_value = mock_blob
+
+    changes = get_edition_changes(mock_bucket, 'current')
+    assert changes['edition'] == 'current'
+    assert len(changes['entries']) == 1
+
+    # Verify it fetches the expected blob path.
+    mock_bucket.blob.assert_called_with('current/changes.json')
+
+    # Mock failed fetch (e.g., blob not found)
+    mock_blob.download_as_text.side_effect = Exception("Not Found")
+    assert get_edition_changes(mock_bucket, 'current') is None
+
+
+def test_format_changelog_date():
+    """Test formatting an ISO timestamp into a short date."""
+    assert format_changelog_date('2026-06-09T10:48:10.406245+00:00') == '9 Jun 2026'
+    assert format_changelog_date('2026-12-25T00:00:00Z') == '25 Dec 2026'
+    # Missing or unparseable timestamps fall back to an empty string.
+    assert format_changelog_date(None) == ''
+    assert format_changelog_date('') == ''
+    assert format_changelog_date('not-a-date') == ''
+
+
+def test_build_changelog():
+    """Test building the 'What's new' panel data from changes.json."""
+    changes = {
+        'edition': 'current',
+        'entries': [
+            {
+                'generated_at': '2026-06-09T10:48:10+00:00',
+                'added': ['New Song - Artist A', 'Another One - Artist B'],
+                'removed': ['Old Song - Artist C'],
+                'added_count': 2,
+                'removed_count': 1,
+            },
+            {
+                'generated_at': '2026-06-02T15:23:23+00:00',
+                'added': ['Hey Jude - The Beatles'],
+                'removed': [],
+                'added_count': 1,
+                'removed_count': 0,
+            },
+        ],
     }
-    result = extract_changelog(manifest)
-    assert result == {
+    result = build_changelog(changes)
+
+    # Latest change is shown in full, with a formatted date.
+    assert result['latest'] == {
+        'date': '9 Jun 2026',
         'added': ['New Song - Artist A', 'Another One - Artist B'],
         'removed': ['Old Song - Artist C'],
     }
 
-    # No changelog key -> None
-    assert extract_changelog({'generated_at': '2024-01-01T12:00:00Z'}) is None
+    # Earlier changes are summarised (date + counts only).
+    assert result['earlier'] == [
+        {'date': '2 Jun 2026', 'added_count': 1, 'removed_count': 0},
+    ]
 
-    # Empty changelog lists -> None
-    assert extract_changelog({'changelog': {'added': [], 'removed': []}}) is None
+    # No changes -> None
+    assert build_changelog(None) is None
+    assert build_changelog({'edition': 'current', 'entries': []}) is None
+    # Entries with no additions or removals are ignored.
+    assert build_changelog({'entries': [{'added': [], 'removed': []}]}) is None
 
-    # None manifest -> None
-    assert extract_changelog(None) is None
+
+def test_build_changelog_counts_fallback():
+    """Counts are derived from the song lists when not provided explicitly."""
+    changes = {
+        'entries': [
+            {'generated_at': '2026-06-09T00:00:00+00:00', 'added': ['A - B'], 'removed': []},
+            {'generated_at': '2026-06-02T00:00:00+00:00', 'added': ['C - D', 'E - F'], 'removed': ['G - H']},
+        ],
+    }
+    result = build_changelog(changes)
+    assert result['earlier'] == [
+        {'date': '2 Jun 2026', 'added_count': 2, 'removed_count': 1},
+    ]
+
+
+def test_build_changelog_history_limit():
+    """The earlier-changes list is capped at the history limit."""
+    entries = [
+        {
+            'generated_at': f'2026-06-{day:02d}T00:00:00+00:00',
+            'added': [f'Song {day}'],
+            'removed': [],
+            'added_count': 1,
+            'removed_count': 0,
+        }
+        for day in range(20, 0, -1)  # 20 entries, newest-first
+    ]
+    result = build_changelog({'entries': entries}, history_limit=10)
+    # 1 latest + 10 earlier shown out of 20 total.
+    assert len(result['earlier']) == 10
 
 
 def test_render_index_with_changelog(sample_supporter_stats):
@@ -437,8 +522,14 @@ def test_render_index_with_changelog(sample_supporter_stats):
         'preview_image': 'previews/current.png',
         'filename': 'current.pdf',
         'changelog': {
-            'added': ['Brand New Song - The Band'],
-            'removed': ['Retired Song - Old Act'],
+            'latest': {
+                'date': '9 Jun 2026',
+                'added': ['Brand New Song - The Band'],
+                'removed': ['Retired Song - Old Act'],
+            },
+            'earlier': [
+                {'date': '2 Jun 2026', 'added_count': 3, 'removed_count': 1},
+            ],
         },
     }]
 
@@ -449,6 +540,11 @@ def test_render_index_with_changelog(sample_supporter_stats):
     assert 'Removed' in html
     assert 'Brand New Song - The Band' in html
     assert 'Retired Song - Old Act' in html
+    # The latest change is dated, and earlier changes are summarised.
+    assert '9 Jun 2026' in html
+    assert 'Earlier changes' in html
+    assert '2 Jun 2026' in html
+    assert '3 added, 1 removed' in html
 
 
 def test_render_index_without_changelog(sample_files, sample_supporter_stats):


### PR DESCRIPTION
## What & why

Companion change for **UkuleleTuesday/songbook-generator#377**, which restructures changelog publishing. The changelog has moved out of the per-date manifest and into an append-only, stable-named **`<edition>/changes.json`** with a history of recent changes (capped at 50 entries, newest-first).

The old design embedded the changelog in each dated manifest. Because the `current` edition republishes multiple times a day, a same-day republish with no song changes overwrote the manifest and blanked the changelog, so the "What's new" panel disappeared. Reading from `changes.json` fixes that and lets us surface more than just the latest diff.

## Changes

- **`build.py`**
  - Add `get_edition_changes(bucket, edition_name)` — fetches `<edition>/changes.json` (mirrors `get_edition_manifest`).
  - Add `build_changelog(changes, history_limit=10)` — builds the panel data: the most recent change plus up to 10 earlier changes, each shaped identically (`date` + `added`/`removed` song lists). Returns `None` when there's nothing to show.
  - Add `format_changelog_date()` — renders entry timestamps as e.g. `9 Jun 2026`.
  - Remove `extract_changelog()` (manifest-based).
  - In `__main__`, the changelog is now sourced from `changes.json` (only when `show_changelog` is set). Manifests are still fetched for the last-updated timestamp.
- **`templates/index.html.j2`** — the "What's new" panel: summary is just **What's new** (no counts); the latest change is shown with its date and the songs added/removed; earlier changes use the **same layout** (shared Jinja macro) and are revealed by an **"Earlier changes…" button**. Progressive enhancement — without JS the earlier entries render inline; with JS they're tucked behind the button.
- **`assets/style.css`** — styles for the date heading, the reveal button, and per-entry separators.
- **`editions.yml`** — updated the `show_changelog` comment to point at `changes.json`.
- **`test_build.py`** — replaced `test_extract_changelog` with tests for `get_edition_changes`, `build_changelog` (incl. history-limit), and `format_changelog_date`; updated the render test for the new structure.

## Panel layout

```
What's new  ▾
  9 Jun 2026
    Added:   Crocodile Rock — Elton John · I Want to Break Free — Queen · …
    Removed: Folsom Prison Blues — Johnny Cash · …
  [ Earlier changes… ]      ← button reveals the dated history below
  2 Jun 2026
    Added:   Grace Kelly — MIKA · Hey Jude — The Beatles · …
    Removed: …
  10 May 2026
    Added:   Pedro — Raffaella Carrà
  …
```

## Testing

- `GCS_BUCKET=ukulele-tuesday-songbooks uv run pytest` → **27 passed**.
- Ran `build.py` end-to-end against the live bucket: `current` now fetches `current/changes.json`; the generated `public/index.html` renders the dated panel and earlier-changes history. Other editions are unaffected.

> [!NOTE]
> Depends on songbook-generator#377 being deployed so `current/changes.json` is published. It is already present in the bucket, so the panel will populate on the next site build; if it were missing, `build_changelog` returns `None` and the panel is simply hidden (no errors).

https://claude.ai/code/session_0191isetRayNPL1kZtj4Dite