### PR TITLE
Render changelog by default when present

### DIFF
--- a/build.py
+++ b/build.py
@@ -68,7 +68,7 @@ def get_editions_config():
             editions.append({
                 'name': name,
                 'hidden': item.get('hidden', False),
-                'show_changelog': item.get('show_changelog', False),
+                'show_changelog': item.get('show_changelog', True),
             })
 
     return editions

--- a/editions.yml
+++ b/editions.yml
@@ -2,10 +2,10 @@
 # Each edition is a dict with 'name' and optional 'hidden: true'.
 # Hidden editions are accessible at /<name>/ but not shown on the site listing.
 #
-# Optional 'show_changelog: true' surfaces a collapsible "What's new" panel on the
-# edition's card, showing the most recent songs added/removed plus a short dated
-# history of earlier changes (sourced from the edition's 'changes.json'). Defaults
-# to false.
+# A collapsible "What's new" panel is surfaced on each edition's card when changes
+# are present, showing the most recent songs added/removed plus a short dated
+# history of earlier changes (sourced from the edition's 'changes.json'). This is
+# enabled by default; set 'show_changelog: false' to suppress it for an edition.
 #
 # Examples:
 #   - name: current        # displayed on site
@@ -20,7 +20,6 @@ editions:
     hidden: true
   - name: current
     hidden: false
-    show_changelog: true
   - name: monopolele-2026
     hidden: true
   - name: complete

--- a/test_build.py
+++ b/test_build.py
@@ -208,6 +208,7 @@ def test_get_editions_config(monkeypatch):
             {'name': 'current', 'show_changelog': True},
             {'name': 'complete'},
             {'name': 'wip', 'hidden': True},
+            {'name': 'archive', 'show_changelog': False},
         ]
     }
     # Use monkeypatch to mock open() and yaml.safe_load()
@@ -215,10 +216,12 @@ def test_get_editions_config(monkeypatch):
     monkeypatch.setattr('build.yaml.safe_load', lambda *args: mock_yaml_content)
 
     editions = get_editions_config()
+    # show_changelog defaults to True; it can be explicitly suppressed per edition.
     assert editions == [
         {'name': 'current', 'hidden': False, 'show_changelog': True},
-        {'name': 'complete', 'hidden': False, 'show_changelog': False},
-        {'name': 'wip', 'hidden': True, 'show_changelog': False},
+        {'name': 'complete', 'hidden': False, 'show_changelog': True},
+        {'name': 'wip', 'hidden': True, 'show_changelog': True},
+        {'name': 'archive', 'hidden': False, 'show_changelog': False},
     ]
 
 def test_get_latest_edition_info():


### PR DESCRIPTION
## Summary

Flips the `show_changelog` toggle so the collapsible **"What's new"** panel is rendered by default on every edition's card whenever changelog data is present, instead of requiring per-edition opt-in.

The `(if present)` behaviour is preserved by the existing pipeline: `build_changelog()` returns `None` when an edition has no `changes.json` data, and the panel is only attached when there's something to show. Editions can still opt out explicitly with `show_changelog: false`.

## Changes

- **`build.py`** — default for `show_changelog` flipped from `False` to `True` in `get_editions_config()`.
- **`editions.yml`** — updated the header comment to document the new default and the `show_changelog: false` opt-out; dropped the now-redundant explicit `show_changelog: true` on the `current` edition.
- **`test_build.py`** — `test_get_editions_config` updated for the new default, plus an `archive` edition added to cover the explicit opt-out case.

## Testing

- `pytest test_build.py` — 27 passed.

https://claude.ai/code/session_01Ct1uGSfy4ZiYbxsywSKDE5

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ct1uGSfy4ZiYbxsywSKDE5)_