### PR TITLE
Fix Buy Me a Coffee (#32): cache data, bail on rate-limits, auth + observability

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,6 +54,18 @@ jobs:
       - name: Install dependencies
         run: uv sync
 
+      # Persist Buy Me a Coffee data between runs so build.py hits the rate-limited
+      # API at most once per TTL (see _fetch_with_cache in build.py). The run_id key
+      # is always unique, so restore falls back to the most recent bmc-cache- entry
+      # and the post-job step always saves the updated cache.
+      - name: Cache Buy Me a Coffee data
+        uses: actions/cache@v4
+        with:
+          path: .bmc-cache
+          key: bmc-cache-${{ github.run_id }}
+          restore-keys: |
+            bmc-cache-
+
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,12 +29,13 @@ permissions:
   # Additional permissions for PR preview deployments
   pull-requests: write
 
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
-# PRs can run concurrently since they don't deploy
+# Production deploys (main / schedule / manual) share the 'pages' group and must
+# NOT cancel an in-progress run, so a deployment always finishes.
+# PR builds use a per-PR group and DO cancel in-progress runs, so a new push
+# supersedes the previous build instead of letting a stale one keep running.
 concurrency:
   group: ${{ github.event_name == 'pull_request' && format('build-pr-{0}', github.event.number) || 'pages' }}
-  cancel-in-progress: false
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   # Build job - runs on all triggers including PRs

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ public/
 __pycache__/
 *.pyc
 .env
+.bmc-cache/

--- a/build.py
+++ b/build.py
@@ -186,6 +186,14 @@ def _response_error_snippet(response, limit=500):
         return body[:limit] + '... (truncated)'
     return body
 
+def _auth_hint(response):
+    """Flag the most common cause of a failed call: an expired/revoked token
+    returns 401/403, or — without an Accept: application/json header — the API
+    redirects to its login page instead of returning a clean 401."""
+    if response.status_code in (401, 403) or response.is_redirect:
+        return " Token may be expired or revoked — regenerate BUYMEACOFFEE_API_TOKEN."
+    return ""
+
 def get_buymeacoffee_stats():
     """Fetch supporter statistics from Buy Me a Coffee API with pagination."""
     # Fallback values in case API fails
@@ -208,7 +216,7 @@ def get_buymeacoffee_stats():
         # Make API request to Buy Me a Coffee with pagination
         headers = {
             'Authorization': f'Bearer {api_token}',
-            'Content-Type': 'application/json'
+            'Accept': 'application/json',
         }
 
         all_supporters = []
@@ -226,11 +234,12 @@ def get_buymeacoffee_stats():
                 'https://developers.buymeacoffee.com/api/v1/supporters',
                 headers=headers,
                 params=params,
-                timeout=10
+                timeout=10,
+                allow_redirects=False
             )
 
             if response.status_code != 200:
-                print(f"  Buy Me a Coffee API returned status {response.status_code} on page {page}, using fallback values. Response body: {_response_error_snippet(response)}")
+                print(f"  Buy Me a Coffee API returned status {response.status_code} on page {page}, using fallback values.{_auth_hint(response)} Response body: {_response_error_snippet(response)}")
                 return fallback_stats
 
             data = response.json()
@@ -305,7 +314,7 @@ def get_buymeacoffee_subscriptions():
         # Make API request to Buy Me a Coffee subscriptions endpoint
         headers = {
             'Authorization': f'Bearer {api_token}',
-            'Content-Type': 'application/json'
+            'Accept': 'application/json',
         }
 
         all_subscriptions = []
@@ -323,11 +332,12 @@ def get_buymeacoffee_subscriptions():
                 'https://developers.buymeacoffee.com/api/v1/subscriptions',
                 headers=headers,
                 params=params,
-                timeout=10
+                timeout=10,
+                allow_redirects=False
             )
 
             if response.status_code != 200:
-                print(f"  Buy Me a Coffee subscriptions API returned status {response.status_code} on page {page}, skipping monthly supporters. Response body: {_response_error_snippet(response)}")
+                print(f"  Buy Me a Coffee subscriptions API returned status {response.status_code} on page {page}, skipping monthly supporters.{_auth_hint(response)} Response body: {_response_error_snippet(response)}")
                 return []
 
             data = response.json()

--- a/build.py
+++ b/build.py
@@ -5,7 +5,7 @@ import shutil
 import json
 import time
 import yaml
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 import fitz  # PyMuPDF
 import requests
 from requests.adapters import HTTPAdapter
@@ -27,6 +27,14 @@ PREVIEW_DIR = os.path.join(OUTPUT_DIR, 'previews')
 TEMPLATE_DIR = 'templates'
 TEMPLATE_FILE = 'index.html.j2'
 EDITIONS_FILE = 'editions.yml'
+
+# Buy Me a Coffee data is cached between builds (persisted via actions/cache) so we
+# hit the rate-limited API at most once per TTL instead of on every 15-min build.
+# The two buckets are cached separately so a failure on one never stales the other.
+CACHE_DIR = '.bmc-cache'
+BMC_CACHE_TTL = timedelta(hours=24)
+DEFAULT_STATS = {'total_amount': 912, 'supporter_count': 61, 'currency': '€'}
+DEFAULT_SUBSCRIPTIONS = []
 # Number of older changelog entries to list under the latest change in the
 # "What's new" panel (the most recent change is always shown in full).
 CHANGELOG_HISTORY_LIMIT = 10
@@ -235,19 +243,16 @@ def _rate_limit_hint(response):
     return ""
 
 def get_buymeacoffee_stats():
-    """Fetch supporter statistics from Buy Me a Coffee API with pagination."""
-    # Fallback values in case API fails
-    fallback_stats = {
-        'total_amount': 912,
-        'supporter_count': 61,
-        'currency': '€'
-    }
+    """Fetch supporter statistics from the Buy Me a Coffee API with pagination.
 
+    Returns a {'total_amount', 'supporter_count', 'currency'} dict on success, or
+    None on any failure so the caller can choose between a cached or default value.
+    """
     # Check if API token is available
     api_token = os.environ.get('BUYMEACOFFEE_API_TOKEN')
     if not api_token:
-        print("  No Buy Me a Coffee API token found, using fallback values")
-        return fallback_stats
+        print("  No Buy Me a Coffee API token found", flush=True)
+        return None
 
     # Tracked out here so the error handlers below can report which page failed.
     page = 1
@@ -285,12 +290,12 @@ def get_buymeacoffee_stats():
                     allow_redirects=False
                 )
             except requests.Timeout:
-                print(f"  Buy Me a Coffee API timed out after 10s on page {page}, using fallback values", flush=True)
-                return fallback_stats
+                print(f"  Buy Me a Coffee API timed out after 10s on page {page}", flush=True)
+                return None
 
             if response.status_code != 200:
-                print(f"  Buy Me a Coffee API returned status {response.status_code} on page {page}, using fallback values.{_auth_hint(response)}{_rate_limit_hint(response)} Response body: {_response_error_snippet(response)}", flush=True)
-                return fallback_stats
+                print(f"  Buy Me a Coffee API returned status {response.status_code} on page {page}.{_auth_hint(response)}{_rate_limit_hint(response)} Response body: {_response_error_snippet(response)}", flush=True)
+                return None
 
             data = response.json()
 
@@ -338,19 +343,23 @@ def get_buymeacoffee_stats():
         }
 
     except requests.RequestException as e:
-        print(f"  Error fetching Buy Me a Coffee stats on page {page}: {e}, using fallback values", flush=True)
-        return fallback_stats
+        print(f"  Error fetching Buy Me a Coffee stats on page {page}: {e}", flush=True)
+        return None
     except Exception as e:
-        print(f"  Unexpected error with Buy Me a Coffee API on page {page}: {e}, using fallback values", flush=True)
-        return fallback_stats
+        print(f"  Unexpected error with Buy Me a Coffee API on page {page}: {e}", flush=True)
+        return None
 
 def get_buymeacoffee_subscriptions():
-    """Fetch active monthly subscriptions from Buy Me a Coffee API with pagination."""
+    """Fetch active monthly subscriptions from the Buy Me a Coffee API.
+
+    Returns a list of supporter names on success (possibly empty), or None on any
+    failure so the caller can fall back to a cached or default value.
+    """
     # Check if API token is available
     api_token = os.environ.get('BUYMEACOFFEE_API_TOKEN')
     if not api_token:
-        print("  No Buy Me a Coffee API token found, skipping monthly supporters")
-        return []
+        print("  No Buy Me a Coffee API token found", flush=True)
+        return None
 
     # Tracked out here so the error handlers below can report which page failed.
     page = 1
@@ -389,12 +398,12 @@ def get_buymeacoffee_subscriptions():
                     allow_redirects=False
                 )
             except requests.Timeout:
-                print(f"  Buy Me a Coffee subscriptions API timed out after 10s on page {page}, skipping monthly supporters", flush=True)
-                return []
+                print(f"  Buy Me a Coffee subscriptions API timed out after 10s on page {page}", flush=True)
+                return None
 
             if response.status_code != 200:
-                print(f"  Buy Me a Coffee subscriptions API returned status {response.status_code} on page {page}, skipping monthly supporters.{_auth_hint(response)}{_rate_limit_hint(response)} Response body: {_response_error_snippet(response)}", flush=True)
-                return []
+                print(f"  Buy Me a Coffee subscriptions API returned status {response.status_code} on page {page}.{_auth_hint(response)}{_rate_limit_hint(response)} Response body: {_response_error_snippet(response)}", flush=True)
+                return None
 
             data = response.json()
 
@@ -430,11 +439,60 @@ def get_buymeacoffee_subscriptions():
         return supporter_names
 
     except requests.RequestException as e:
-        print(f"  Error fetching Buy Me a Coffee subscriptions on page {page}: {e}, skipping monthly supporters", flush=True)
-        return []
+        print(f"  Error fetching Buy Me a Coffee subscriptions on page {page}: {e}", flush=True)
+        return None
     except Exception as e:
-        print(f"  Unexpected error with Buy Me a Coffee subscriptions API on page {page}: {e}, skipping monthly supporters", flush=True)
-        return []
+        print(f"  Unexpected error with Buy Me a Coffee subscriptions API on page {page}: {e}", flush=True)
+        return None
+
+def _cache_path(name):
+    return os.path.join(CACHE_DIR, f'{name}.json')
+
+def _read_cache(name):
+    """Return the cached {'fetched_at', 'data'} entry, or None if missing/unreadable."""
+    try:
+        with open(_cache_path(name)) as f:
+            return json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return None
+
+def _write_cache(name, data):
+    """Persist `data` under `name` with the current UTC timestamp."""
+    os.makedirs(CACHE_DIR, exist_ok=True)
+    with open(_cache_path(name), 'w') as f:
+        json.dump({'fetched_at': datetime.now(timezone.utc).isoformat(), 'data': data}, f, indent=2)
+
+def _cache_age(entry):
+    """Age of a cache entry; treat a missing/unparseable timestamp as infinitely old."""
+    try:
+        fetched_at = datetime.fromisoformat(entry['fetched_at'])
+    except (KeyError, TypeError, ValueError):
+        return timedelta.max
+    return datetime.now(timezone.utc) - fetched_at
+
+def _fetch_with_cache(name, fetch_fn, default, label, ttl=BMC_CACHE_TTL):
+    """Return cached data when it's within `ttl`, otherwise fetch fresh.
+
+    Each bucket (stats, subscriptions) is cached independently. On a failed fetch
+    (fetch_fn returns None) we reuse the last cached value, falling back to
+    `default` only when there is no cache at all.
+    """
+    entry = _read_cache(name)
+    if entry is not None and _cache_age(entry) < ttl:
+        print(f"  Using cached {label} (fetched {entry['fetched_at']}) — skipping BMC call", flush=True)
+        return entry['data']
+
+    data = fetch_fn()
+    if data is not None:
+        _write_cache(name, data)
+        return data
+
+    if entry is not None:
+        print(f"  {label} fetch failed; reusing last cached value from {entry['fetched_at']}", flush=True)
+        return entry['data']
+
+    print(f"  {label} fetch failed and no cache available; using built-in default", flush=True)
+    return default
 
 def download_pdf_from_url(url):
     """Downloads a PDF from a URL and returns the bytes."""
@@ -503,13 +561,13 @@ if __name__ == '__main__':
 
     os.makedirs(PREVIEW_DIR, exist_ok=True)
 
-    # Fetch Buy Me a Coffee supporter statistics
+    # Buy Me a Coffee supporter stats — cached between builds (see _fetch_with_cache)
     print("Fetching Buy Me a Coffee supporter statistics...")
-    supporter_stats = get_buymeacoffee_stats()
+    supporter_stats = _fetch_with_cache('stats', get_buymeacoffee_stats, DEFAULT_STATS, 'supporter stats')
 
-    # Fetch Buy Me a Coffee monthly subscriptions
+    # Buy Me a Coffee monthly supporters — cached separately
     print("Fetching Buy Me a Coffee monthly supporters...")
-    monthly_supporters = get_buymeacoffee_subscriptions()
+    monthly_supporters = _fetch_with_cache('subscriptions', get_buymeacoffee_subscriptions, DEFAULT_SUBSCRIPTIONS, 'monthly supporters')
 
     latest_update_time = None
 

--- a/build.py
+++ b/build.py
@@ -66,9 +66,13 @@ def create_session_with_retry(max_retries=5, backoff_factor=1):
     retry = _LoggingRetry(
         total=max_retries,
         backoff_factor=backoff_factor,       # exponential backoff: 1s, 2s, 4s…
-        status_forcelist=[429],              # retry on rate limit
-        allowed_methods=['GET'],             # only retry GET requests
-        respect_retry_after_header=True,
+        # Don't auto-retry HTTP error statuses. BMC answers a 429 rate limit with
+        # Retry-After: 3600 — not job-friendly — so retrying/honoring it would
+        # block the build for up to an hour. We surface the 429 immediately and
+        # bail to fallback values in the caller instead.
+        status_forcelist=[],
+        allowed_methods=['GET'],             # only retry transient connection errors
+        respect_retry_after_header=False,
         raise_on_status=False,               # don't raise exceptions, return response
     )
     
@@ -223,6 +227,13 @@ def _auth_hint(response):
         return " Token may be expired or revoked — regenerate BUYMEACOFFEE_API_TOKEN."
     return ""
 
+def _rate_limit_hint(response):
+    """For a 429, surface the Retry-After we're deliberately not honoring."""
+    if response.status_code == 429:
+        retry_after = response.headers.get('Retry-After')
+        return f" Rate-limited; Retry-After={retry_after}s is not job-friendly, bailing to fallback."
+    return ""
+
 def get_buymeacoffee_stats():
     """Fetch supporter statistics from Buy Me a Coffee API with pagination."""
     # Fallback values in case API fails
@@ -278,7 +289,7 @@ def get_buymeacoffee_stats():
                 return fallback_stats
 
             if response.status_code != 200:
-                print(f"  Buy Me a Coffee API returned status {response.status_code} on page {page}, using fallback values.{_auth_hint(response)} Response body: {_response_error_snippet(response)}", flush=True)
+                print(f"  Buy Me a Coffee API returned status {response.status_code} on page {page}, using fallback values.{_auth_hint(response)}{_rate_limit_hint(response)} Response body: {_response_error_snippet(response)}", flush=True)
                 return fallback_stats
 
             data = response.json()
@@ -382,7 +393,7 @@ def get_buymeacoffee_subscriptions():
                 return []
 
             if response.status_code != 200:
-                print(f"  Buy Me a Coffee subscriptions API returned status {response.status_code} on page {page}, skipping monthly supporters.{_auth_hint(response)} Response body: {_response_error_snippet(response)}", flush=True)
+                print(f"  Buy Me a Coffee subscriptions API returned status {response.status_code} on page {page}, skipping monthly supporters.{_auth_hint(response)}{_rate_limit_hint(response)} Response body: {_response_error_snippet(response)}", flush=True)
                 return []
 
             data = response.json()

--- a/build.py
+++ b/build.py
@@ -2,6 +2,7 @@ import os
 import io
 import shutil
 import json
+import time
 import yaml
 from datetime import datetime, timezone
 import fitz  # PyMuPDF
@@ -209,6 +210,8 @@ def get_buymeacoffee_stats():
         print("  No Buy Me a Coffee API token found, using fallback values")
         return fallback_stats
 
+    # Tracked out here so the error handlers below can report which page failed.
+    page = 1
     try:
         # Create session with retry configuration
         session = create_session_with_retry()
@@ -220,9 +223,9 @@ def get_buymeacoffee_stats():
         }
 
         all_supporters = []
-        page = 1
         page_size = 50  # Larger page size to get more results per request
         total_pages = 1  # Assume at least one page
+        start_time = time.monotonic()
 
         while True:
             params = {
@@ -230,16 +233,24 @@ def get_buymeacoffee_stats():
                 'per_page': page_size
             }
 
-            response = session.get(
-                'https://developers.buymeacoffee.com/api/v1/supporters',
-                headers=headers,
-                params=params,
-                timeout=10,
-                allow_redirects=False
-            )
+            # Logged and flushed *before* the request so a hang or timeout shows
+            # exactly which page stalled instead of the log going silent.
+            print(f"  Requesting supporters page {page}/{total_pages} (per_page={page_size}, timeout=10s)...", flush=True)
+
+            try:
+                response = session.get(
+                    'https://developers.buymeacoffee.com/api/v1/supporters',
+                    headers=headers,
+                    params=params,
+                    timeout=10,
+                    allow_redirects=False
+                )
+            except requests.Timeout:
+                print(f"  Buy Me a Coffee API timed out after 10s on page {page}, using fallback values", flush=True)
+                return fallback_stats
 
             if response.status_code != 200:
-                print(f"  Buy Me a Coffee API returned status {response.status_code} on page {page}, using fallback values.{_auth_hint(response)} Response body: {_response_error_snippet(response)}")
+                print(f"  Buy Me a Coffee API returned status {response.status_code} on page {page}, using fallback values.{_auth_hint(response)} Response body: {_response_error_snippet(response)}", flush=True)
                 return fallback_stats
 
             data = response.json()
@@ -248,25 +259,19 @@ def get_buymeacoffee_stats():
                 # On the first request, get the total number of pages
                 total_pages = data.get('last_page', 1)
 
-            print(f"  Fetching page {page}/{total_pages}...")
-
             supporters = data.get('data', [])
-
-            if not supporters:
-                # No more supporters to fetch
-                break
-
             all_supporters.extend(supporters)
+            print(f"    page {page}/{total_pages}: received {len(supporters)} supporters (running total {len(all_supporters)})", flush=True)
 
-            # Check if we've reached the last page
-            if data.get('next_page_url') is None:
+            # Stop on an empty page or when the API reports no further pages.
+            if not supporters or data.get('next_page_url') is None:
                 break
 
             page += 1
 
             # Safety break to avoid infinite loops
             if page > 100:
-                print(f"  Warning: Stopped at page {page} to avoid infinite loop")
+                print(f"  Warning: Stopped at page {page} to avoid infinite loop", flush=True)
                 break
 
         # Calculate totals from all supporters
@@ -284,7 +289,8 @@ def get_buymeacoffee_stats():
                 # Skip this supporter if values can't be converted to numbers
                 continue
 
-        print(f"  Fetched Buy Me a Coffee stats: €{int(total_amount)} from {supporter_count} supporters ({page} pages)")
+        elapsed = time.monotonic() - start_time
+        print(f"  Fetched Buy Me a Coffee stats: €{int(total_amount)} from {supporter_count} supporters across {page} page(s) in {elapsed:.1f}s", flush=True)
 
         return {
             'total_amount': int(total_amount),
@@ -293,10 +299,10 @@ def get_buymeacoffee_stats():
         }
 
     except requests.RequestException as e:
-        print(f"  Error fetching Buy Me a Coffee stats: {e}, using fallback values")
+        print(f"  Error fetching Buy Me a Coffee stats on page {page}: {e}, using fallback values", flush=True)
         return fallback_stats
     except Exception as e:
-        print(f"  Unexpected error with Buy Me a Coffee API: {e}, using fallback values")
+        print(f"  Unexpected error with Buy Me a Coffee API on page {page}: {e}, using fallback values", flush=True)
         return fallback_stats
 
 def get_buymeacoffee_subscriptions():
@@ -307,6 +313,8 @@ def get_buymeacoffee_subscriptions():
         print("  No Buy Me a Coffee API token found, skipping monthly supporters")
         return []
 
+    # Tracked out here so the error handlers below can report which page failed.
+    page = 1
     try:
         # Create session with retry configuration
         session = create_session_with_retry()
@@ -318,8 +326,9 @@ def get_buymeacoffee_subscriptions():
         }
 
         all_subscriptions = []
-        page = 1
         page_size = 50  # Larger page size to get more results per request
+        total_pages = 1  # Assume at least one page
+        start_time = time.monotonic()
 
         while True:
             params = {
@@ -328,39 +337,45 @@ def get_buymeacoffee_subscriptions():
                 'status': 'active'
             }
 
-            response = session.get(
-                'https://developers.buymeacoffee.com/api/v1/subscriptions',
-                headers=headers,
-                params=params,
-                timeout=10,
-                allow_redirects=False
-            )
+            # Logged and flushed *before* the request so a hang or timeout shows
+            # exactly which page stalled instead of the log going silent.
+            print(f"  Requesting subscriptions page {page}/{total_pages} (per_page={page_size}, timeout=10s)...", flush=True)
+
+            try:
+                response = session.get(
+                    'https://developers.buymeacoffee.com/api/v1/subscriptions',
+                    headers=headers,
+                    params=params,
+                    timeout=10,
+                    allow_redirects=False
+                )
+            except requests.Timeout:
+                print(f"  Buy Me a Coffee subscriptions API timed out after 10s on page {page}, skipping monthly supporters", flush=True)
+                return []
 
             if response.status_code != 200:
-                print(f"  Buy Me a Coffee subscriptions API returned status {response.status_code} on page {page}, skipping monthly supporters.{_auth_hint(response)} Response body: {_response_error_snippet(response)}")
+                print(f"  Buy Me a Coffee subscriptions API returned status {response.status_code} on page {page}, skipping monthly supporters.{_auth_hint(response)} Response body: {_response_error_snippet(response)}", flush=True)
                 return []
 
             data = response.json()
 
-            print(f"  Fetching subscriptions page {page}...")
+            if page == 1:
+                # On the first request, get the total number of pages
+                total_pages = data.get('last_page', 1)
 
             subscriptions = data.get('data', [])
-
-            if not subscriptions:
-                # No more subscriptions to fetch
-                break
-
             all_subscriptions.extend(subscriptions)
+            print(f"    page {page}/{total_pages}: received {len(subscriptions)} subscriptions (running total {len(all_subscriptions)})", flush=True)
 
-            # Check if we've reached the last page
-            if data.get('next_page_url') is None:
+            # Stop on an empty page or when the API reports no further pages.
+            if not subscriptions or data.get('next_page_url') is None:
                 break
 
             page += 1
 
             # Safety break to avoid infinite loops
             if page > 100:
-                print(f"  Warning: Stopped at page {page} to avoid infinite loop")
+                print(f"  Warning: Stopped at page {page} to avoid infinite loop", flush=True)
                 break
 
         # Extract supporter names from subscriptions
@@ -370,15 +385,16 @@ def get_buymeacoffee_subscriptions():
             if name:
                 supporter_names.append(name)
 
-        print(f"  Fetched {len(supporter_names)} monthly supporters from Buy Me a Coffee")
+        elapsed = time.monotonic() - start_time
+        print(f"  Fetched {len(supporter_names)} monthly supporters from Buy Me a Coffee across {page} page(s) in {elapsed:.1f}s", flush=True)
 
         return supporter_names
 
     except requests.RequestException as e:
-        print(f"  Error fetching Buy Me a Coffee subscriptions: {e}, skipping monthly supporters")
+        print(f"  Error fetching Buy Me a Coffee subscriptions on page {page}: {e}, skipping monthly supporters", flush=True)
         return []
     except Exception as e:
-        print(f"  Unexpected error with Buy Me a Coffee subscriptions API: {e}, skipping monthly supporters")
+        print(f"  Unexpected error with Buy Me a Coffee subscriptions API on page {page}: {e}, skipping monthly supporters", flush=True)
         return []
 
 def download_pdf_from_url(url):

--- a/build.py
+++ b/build.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import io
 import shutil
 import json
@@ -11,6 +12,12 @@ from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 from google.cloud import storage
 from jinja2 import Environment, FileSystemLoader
+
+# Stream stdout line-by-line so CI logs show progress live, instead of staying
+# silent until a block buffer fills or the process exits — which previously hid
+# where a slow/hung build was actually stuck.
+if hasattr(sys.stdout, 'reconfigure'):
+    sys.stdout.reconfigure(line_buffering=True)
 
 # Configuration
 BUCKET_NAME = os.environ['GCS_BUCKET']

--- a/build.py
+++ b/build.py
@@ -31,6 +31,27 @@ EDITIONS_FILE = 'editions.yml'
 # "What's new" panel (the most recent change is always shown in full).
 CHANGELOG_HISTORY_LIMIT = 10
 
+class _LoggingRetry(Retry):
+    """A urllib3 Retry that announces each wait it takes.
+
+    Retries — especially Retry-After sleeps on 429s — are otherwise silent, so a
+    rate-limited request looks like a multi-minute hang with no explanation.
+    This logs which status triggered the retry and how long we're about to wait.
+    """
+
+    def sleep(self, response=None):
+        retry_after = None
+        if response is not None and self.respect_retry_after_header:
+            retry_after = self.get_retry_after(response)
+        if retry_after:
+            print(f"    BMC retry: status {response.status}, honoring Retry-After — sleeping {retry_after:.0f}s", flush=True)
+        else:
+            backoff = self.get_backoff_time()
+            if backoff > 0:
+                where = f"status {response.status}" if response is not None else "connection error"
+                print(f"    BMC retry: {where} — backing off {backoff:.1f}s", flush=True)
+        super().sleep(response)
+
 def create_session_with_retry(max_retries=5, backoff_factor=1):
     """
     Creates a requests Session with retry configuration for 429 errors.
@@ -42,7 +63,7 @@ def create_session_with_retry(max_retries=5, backoff_factor=1):
     Returns:
         requests.Session configured with retry adapter
     """
-    retry = Retry(
+    retry = _LoggingRetry(
         total=max_retries,
         backoff_factor=backoff_factor,       # exponential backoff: 1s, 2s, 4s…
         status_forcelist=[429],              # retry on rate limit

--- a/test_build.py
+++ b/test_build.py
@@ -646,6 +646,8 @@ def test_get_buymeacoffee_stats_success(requests_mock):
         # Should succeed on first try
         assert result['total_amount'] == 15  # 5 * 3
         assert result['supporter_count'] == 1
+        # Must request JSON so auth failures come back as a clean 401, not a login redirect
+        assert requests_mock.last_request.headers.get('Accept') == 'application/json'
     finally:
         if 'BUYMEACOFFEE_API_TOKEN' in os.environ:
             del os.environ['BUYMEACOFFEE_API_TOKEN']
@@ -670,6 +672,29 @@ def test_get_buymeacoffee_stats_fallback_on_error(requests_mock, capsys):
         captured = capsys.readouterr()
         assert 'status 502' in captured.out
         assert 'Bad Gateway: upstream timed out' in captured.out
+    finally:
+        if 'BUYMEACOFFEE_API_TOKEN' in os.environ:
+            del os.environ['BUYMEACOFFEE_API_TOKEN']
+
+
+def test_get_buymeacoffee_stats_401_flags_token(requests_mock, capsys):
+    """A 401 (expired/revoked token) should fall back and flag the token, not a phantom 502."""
+    os.environ['BUYMEACOFFEE_API_TOKEN'] = 'test-token'
+
+    base_url = 'https://developers.buymeacoffee.com/api/v1/supporters'
+
+    # Mirrors the real failure: with Accept: application/json the API returns a clean 401
+    requests_mock.get(base_url, status_code=401, json={'error': 'Unauthenticated.'})
+
+    try:
+        result = get_buymeacoffee_stats()
+
+        # Falls back, and the log points at the token rather than a misleading gateway error
+        assert result['total_amount'] == 912
+        captured = capsys.readouterr()
+        assert 'status 401' in captured.out
+        assert 'Unauthenticated' in captured.out
+        assert 'regenerate BUYMEACOFFEE_API_TOKEN' in captured.out
     finally:
         if 'BUYMEACOFFEE_API_TOKEN' in os.environ:
             del os.environ['BUYMEACOFFEE_API_TOKEN']

--- a/test_build.py
+++ b/test_build.py
@@ -791,5 +791,24 @@ def test_get_buymeacoffee_subscriptions_empty_on_error(requests_mock, capsys):
             del os.environ['BUYMEACOFFEE_API_TOKEN']
 
 
+def test_logging_retry_announces_retry_after(capsys, monkeypatch):
+    """The retry logs each wait, so a rate-limited request isn't a silent gap."""
+    import time
+    from unittest.mock import MagicMock
+    from build import _LoggingRetry
+
+    # Don't actually sleep through the Retry-After during the test.
+    monkeypatch.setattr(time, 'sleep', lambda *a, **k: None)
+
+    retry = _LoggingRetry(total=5, status_forcelist=[429], respect_retry_after_header=True)
+    response = MagicMock(status=429, headers={'Retry-After': '5'})
+    retry.sleep(response)
+
+    out = capsys.readouterr().out
+    assert 'status 429' in out
+    assert 'Retry-After' in out
+    assert 'sleeping 5s' in out
+
+
 if __name__ == '__main__':
     pytest.main([__file__, '-v'])

--- a/test_build.py
+++ b/test_build.py
@@ -700,6 +700,48 @@ def test_get_buymeacoffee_stats_401_flags_token(requests_mock, capsys):
             del os.environ['BUYMEACOFFEE_API_TOKEN']
 
 
+def test_get_buymeacoffee_stats_timeout_logs_page(requests_mock, capsys):
+    """A request timeout falls back and logs which page timed out."""
+    import requests
+    os.environ['BUYMEACOFFEE_API_TOKEN'] = 'test-token'
+
+    base_url = 'https://developers.buymeacoffee.com/api/v1/supporters'
+    requests_mock.get(base_url, exc=requests.exceptions.Timeout)
+
+    try:
+        result = get_buymeacoffee_stats()
+
+        assert result['total_amount'] == 912  # fallback
+        captured = capsys.readouterr()
+        assert 'timed out after 10s on page 1' in captured.out
+    finally:
+        if 'BUYMEACOFFEE_API_TOKEN' in os.environ:
+            del os.environ['BUYMEACOFFEE_API_TOKEN']
+
+
+def test_get_buymeacoffee_stats_logs_progress(requests_mock, capsys):
+    """A successful fetch logs per-page progress (with running totals) and elapsed time."""
+    os.environ['BUYMEACOFFEE_API_TOKEN'] = 'test-token'
+
+    base_url = 'https://developers.buymeacoffee.com/api/v1/supporters'
+    requests_mock.get(
+        base_url,
+        json={'data': [{'support_coffees': '3', 'support_coffee_price': '3'}], 'next_page_url': None},
+        status_code=200,
+    )
+
+    try:
+        get_buymeacoffee_stats()
+
+        out = capsys.readouterr().out
+        assert 'Requesting supporters page 1' in out   # progress, printed before the request
+        assert 'running total 1' in out                # per-page running total
+        assert 'page(s) in' in out                     # elapsed-time summary
+    finally:
+        if 'BUYMEACOFFEE_API_TOKEN' in os.environ:
+            del os.environ['BUYMEACOFFEE_API_TOKEN']
+
+
 def test_get_buymeacoffee_subscriptions_success(requests_mock):
     """Test successful API call for subscriptions."""
     os.environ['BUYMEACOFFEE_API_TOKEN'] = 'test-token'

--- a/test_build.py
+++ b/test_build.py
@@ -619,8 +619,8 @@ def test_create_session_with_retry():
     adapter = session.adapters["https://"]
     assert adapter.max_retries.total == 3
     assert adapter.max_retries.backoff_factor == 2
-    assert 429 in adapter.max_retries.status_forcelist
-    assert adapter.max_retries.respect_retry_after_header is True
+    assert 429 not in adapter.max_retries.status_forcelist  # we bail on 429, not retry it
+    assert adapter.max_retries.respect_retry_after_header is False
     assert 'GET' in adapter.max_retries.allowed_methods
     assert adapter.max_retries.raise_on_status is False
 
@@ -695,6 +695,26 @@ def test_get_buymeacoffee_stats_401_flags_token(requests_mock, capsys):
         assert 'status 401' in captured.out
         assert 'Unauthenticated' in captured.out
         assert 'regenerate BUYMEACOFFEE_API_TOKEN' in captured.out
+    finally:
+        if 'BUYMEACOFFEE_API_TOKEN' in os.environ:
+            del os.environ['BUYMEACOFFEE_API_TOKEN']
+
+
+def test_get_buymeacoffee_stats_429_bails_with_retry_after(requests_mock, capsys):
+    """A 429 bails to fallback immediately and logs the (unhonored) Retry-After."""
+    os.environ['BUYMEACOFFEE_API_TOKEN'] = 'test-token'
+
+    base_url = 'https://developers.buymeacoffee.com/api/v1/supporters'
+    requests_mock.get(base_url, status_code=429, headers={'Retry-After': '3600'}, json={'error': 'Too Many Requests'})
+
+    try:
+        result = get_buymeacoffee_stats()
+
+        assert result['total_amount'] == 912  # fallback, no waiting
+        out = capsys.readouterr().out
+        assert 'status 429' in out
+        assert 'Retry-After=3600' in out
+        assert 'bailing to fallback' in out
     finally:
         if 'BUYMEACOFFEE_API_TOKEN' in os.environ:
             del os.environ['BUYMEACOFFEE_API_TOKEN']

--- a/test_build.py
+++ b/test_build.py
@@ -127,10 +127,8 @@ def test_get_buymeacoffee_stats_api_error(requests_mock):
     try:
         result = get_buymeacoffee_stats()
         
-        # Should return fallback values
-        assert result['total_amount'] == 912
-        assert result['supporter_count'] == 61
-        assert result['currency'] == '€'
+        # Failure returns None; the caller falls back to cache/default
+        assert result is None
     finally:
         # Clean up environment variable
         if 'BUYMEACOFFEE_API_TOKEN' in os.environ:
@@ -144,10 +142,8 @@ def test_get_buymeacoffee_stats_no_token():
     
     result = get_buymeacoffee_stats()
     
-    # Should return fallback values
-    assert result['total_amount'] == 912
-    assert result['supporter_count'] == 61
-    assert result['currency'] == '€'
+    # Failure returns None; the caller falls back to cache/default
+    assert result is None
 
 def test_get_buymeacoffee_stats_invalid_data(requests_mock):
     """Test Buy Me a Coffee API with invalid data types."""
@@ -328,8 +324,8 @@ def test_get_buymeacoffee_subscriptions_no_token():
     
     result = get_buymeacoffee_subscriptions()
     
-    # Should return empty list
-    assert result == []
+    # Failure returns None; the caller falls back to cache/default
+    assert result is None
 
 def test_get_buymeacoffee_subscriptions_api_error(requests_mock):
     """Test subscriptions API error handling."""
@@ -346,8 +342,8 @@ def test_get_buymeacoffee_subscriptions_api_error(requests_mock):
     try:
         result = get_buymeacoffee_subscriptions()
         
-        # Should return empty list
-        assert result == []
+        # Failure returns None; the caller falls back to cache/default
+        assert result is None
     finally:
         # Clean up environment variable
         if 'BUYMEACOFFEE_API_TOKEN' in os.environ:
@@ -665,9 +661,8 @@ def test_get_buymeacoffee_stats_fallback_on_error(requests_mock, capsys):
     try:
         result = get_buymeacoffee_stats()
 
-        # Should return fallback values
-        assert result['total_amount'] == 912
-        assert result['supporter_count'] == 61
+        # Failure returns None; the caller falls back to cache/default
+        assert result is None
         # The response body must be surfaced in logs for diagnosis
         captured = capsys.readouterr()
         assert 'status 502' in captured.out
@@ -689,8 +684,8 @@ def test_get_buymeacoffee_stats_401_flags_token(requests_mock, capsys):
     try:
         result = get_buymeacoffee_stats()
 
-        # Falls back, and the log points at the token rather than a misleading gateway error
-        assert result['total_amount'] == 912
+        # Returns None; the log points at the token rather than a misleading gateway error
+        assert result is None
         captured = capsys.readouterr()
         assert 'status 401' in captured.out
         assert 'Unauthenticated' in captured.out
@@ -710,7 +705,7 @@ def test_get_buymeacoffee_stats_429_bails_with_retry_after(requests_mock, capsys
     try:
         result = get_buymeacoffee_stats()
 
-        assert result['total_amount'] == 912  # fallback, no waiting
+        assert result is None  # bailed, no waiting
         out = capsys.readouterr().out
         assert 'status 429' in out
         assert 'Retry-After=3600' in out
@@ -731,7 +726,7 @@ def test_get_buymeacoffee_stats_timeout_logs_page(requests_mock, capsys):
     try:
         result = get_buymeacoffee_stats()
 
-        assert result['total_amount'] == 912  # fallback
+        assert result is None  # failed fetch
         captured = capsys.readouterr()
         assert 'timed out after 10s on page 1' in captured.out
     finally:
@@ -800,8 +795,8 @@ def test_get_buymeacoffee_subscriptions_empty_on_error(requests_mock, capsys):
     try:
         result = get_buymeacoffee_subscriptions()
 
-        # Should return empty list
-        assert result == []
+        # Failure returns None; the caller falls back to cache/default
+        assert result is None
         # The response body must be surfaced in logs for diagnosis
         captured = capsys.readouterr()
         assert 'status 502' in captured.out
@@ -828,6 +823,55 @@ def test_logging_retry_announces_retry_after(capsys, monkeypatch):
     assert 'status 429' in out
     assert 'Retry-After' in out
     assert 'sleeping 5s' in out
+
+
+def test_fetch_with_cache_uses_fresh_cache(tmp_path, monkeypatch):
+    """A fresh cache is used and the fetcher is not called."""
+    import build
+    monkeypatch.setattr(build, 'CACHE_DIR', str(tmp_path))
+    build._write_cache('stats', {'total_amount': 500, 'supporter_count': 25, 'currency': '€'})
+
+    called = []
+    def fetch():
+        called.append(True)
+        return {'total_amount': 999, 'supporter_count': 99, 'currency': '€'}
+
+    result = build._fetch_with_cache('stats', fetch, build.DEFAULT_STATS, 'supporter stats')
+    assert result == {'total_amount': 500, 'supporter_count': 25, 'currency': '€'}
+    assert called == []  # fetcher skipped
+
+
+def test_fetch_with_cache_refetches_when_stale(tmp_path, monkeypatch):
+    """A missing cache triggers a fresh fetch, which is then persisted."""
+    import build
+    monkeypatch.setattr(build, 'CACHE_DIR', str(tmp_path))
+
+    fresh = {'total_amount': 999, 'supporter_count': 99, 'currency': '€'}
+    result = build._fetch_with_cache('stats', lambda: fresh, build.DEFAULT_STATS, 'supporter stats')
+
+    assert result == fresh
+    assert build._read_cache('stats')['data'] == fresh
+
+
+def test_fetch_with_cache_reuses_stale_on_failure(tmp_path, monkeypatch):
+    """When the fetch fails (None) but a cache exists, reuse the cached value."""
+    import build
+    monkeypatch.setattr(build, 'CACHE_DIR', str(tmp_path))
+    build._write_cache('subscriptions', ['Alice', 'Bob'])
+    # Force the entry to look stale so a fetch is attempted.
+    monkeypatch.setattr(build, '_cache_age', lambda entry: build.timedelta(days=999))
+
+    result = build._fetch_with_cache('subscriptions', lambda: None, build.DEFAULT_SUBSCRIPTIONS, 'monthly supporters')
+    assert result == ['Alice', 'Bob']
+
+
+def test_fetch_with_cache_falls_back_to_default(tmp_path, monkeypatch):
+    """No cache plus a failed fetch falls back to the built-in default."""
+    import build
+    monkeypatch.setattr(build, 'CACHE_DIR', str(tmp_path))
+
+    result = build._fetch_with_cache('stats', lambda: None, build.DEFAULT_STATS, 'supporter stats')
+    assert result == build.DEFAULT_STATS
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #32. The investigation (see issue) proved the BMC "outage" was an **expired token** masked by a missing `Accept` header, and the multi-minute "hangs" were our own **rate-limiting** (40 paginated stats calls + subs, every 15 min) — BMC answers with `429 / Retry-After: 3600`. This PR fixes the auth, makes the build observable, and stops hammering the API.

### Cache BMC data across builds (the cure)
- `.bmc-cache/{stats,subscriptions}.json` persisted via `actions/cache@v4` (rolling `run_id` key + `bmc-cache-` restore-keys).
- `_fetch_with_cache` uses cached data within `BMC_CACHE_TTL` (24h, daily) and **skips the API**; on a failed fetch it reuses the last cached value, falling back to a built-in default only with no cache at all.
- **Stats and subscriptions cached separately** — a rate limit on one never stales the other.
- Fetchers now return `None` on failure (defaults moved to `DEFAULT_STATS`/`DEFAULT_SUBSCRIPTIONS`) so caching can distinguish a real result from a failure.

### Don't let a 429 block the build
- Dropped 429 from the retry `status_forcelist` and stopped honoring `Retry-After` — a rate limit returns immediately and bails to the cached/default value, logging the (unhonored) `Retry-After`.

### Auth fix
- Send `Accept: application/json` (→ clean `401` instead of `302→/login` followed into a phantom `502`), `allow_redirects=False`, and a "regenerate the token" hint on 401/403.

### Observability
- stdout is line-buffered so logs stream live (no more silent multi-minute steps).
- Per-page `Requesting … page X/Y` with running totals, named timeouts, page numbers in errors, elapsed time, and a `_LoggingRetry` that announces each retry wait.

### CI
- PR builds use `cancel-in-progress` so a new push supersedes a stale run; production (`pages`) deploys never get interrupted.

## Test plan
- [x] `GCS_BUCKET=test-bucket uv run pytest test_build.py` → **36 passed** (incl. cache fresh-hit / cold-refetch+persist / stale-reuse-on-failure / default-on-no-cache).
- [x] Local smoke: cold `_fetch_with_cache` fetches+writes; warm call logs "Using cached … — skipping BMC call" and does not fetch.
- [ ] On the deployed build: warm cache shows **no** `Requesting supporters page …` lines; daily refresh updates the numbers.

https://claude.ai/code/session_014UiLhSZHs4WS6kfUMULyED