### PR TITLE
Link changelog songs to their chord sheets

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -49,7 +49,7 @@
       grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
       gap: 1.5em;
     }
-    .songbook-item a {
+    .songbook-item > a {
       display: flex;
       flex-direction: column;
       height: 100%;
@@ -61,7 +61,7 @@
       border: 1px solid #eee;
       transition: transform 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
     }
-    .songbook-item a:hover {
+    .songbook-item > a:hover {
       transform: translateY(-5px);
       box-shadow: 0 8px 20px rgba(0,0,0,0.08);
     }

--- a/assets/style.css
+++ b/assets/style.css
@@ -166,12 +166,43 @@
       padding: 0;
     }
     .songbook-changelog li {
-      padding: 0.15em 0;
+      padding: 0.15em 0 0.15em 1.3em;
       color: #555;
-      border-bottom: 1px solid #f3f3f3;
     }
-    .songbook-changelog li:last-child {
-      border-bottom: none;
+    .songbook-changelog .changelog-group li::before {
+      display: inline-block;
+      width: 1.3em;
+      margin-left: -1.3em;
+      font-weight: bold;
+      text-align: left;
+    }
+    .songbook-changelog .changelog-added li::before {
+      content: "＋";
+      color: var(--primary-color);
+    }
+    .songbook-changelog .changelog-removed li::before {
+      content: "－";
+      color: var(--heart-color);
+    }
+    .songbook-changelog a {
+      color: var(--text-color);
+      text-decoration: none;
+    }
+    .songbook-changelog a::after {
+      content: "\2197\FE0E";
+      margin-left: 0.2em;
+      font-size: 0.85em;
+      color: #999;
+    }
+    .songbook-changelog a:hover,
+    .songbook-changelog a:focus-visible {
+      color: var(--primary-color);
+      text-decoration: underline;
+      text-underline-offset: 2px;
+    }
+    .songbook-changelog a:hover::after,
+    .songbook-changelog a:focus-visible::after {
+      color: var(--primary-color);
     }
     .songbook-changelog .changelog-date {
       margin-top: 0.4em;

--- a/build.py
+++ b/build.py
@@ -1,9 +1,11 @@
 import os
 import sys
 import io
+import re
 import shutil
 import json
 import time
+import unicodedata
 import yaml
 from datetime import datetime, timedelta, timezone
 import fitz  # PyMuPDF
@@ -22,6 +24,9 @@ if hasattr(sys.stdout, 'reconfigure'):
 # Configuration
 BUCKET_NAME = os.environ['GCS_BUCKET']
 BASE_URL = 'https://songbooks.ukuleletuesday.ie'
+# Base URL for individual song chord sheets on the songs site. Changelog songs
+# are linked here so readers can jump straight to a sheet that was added.
+SONGS_SHEET_BASE_URL = 'https://ukuleletuesday.github.io/songs/sheets'
 OUTPUT_DIR = 'public'
 PREVIEW_DIR = os.path.join(OUTPUT_DIR, 'previews')
 TEMPLATE_DIR = 'templates'
@@ -171,13 +176,44 @@ def format_changelog_date(generated_at):
         return ''
     return f"{dt.day} {dt:%b %Y}"
 
+def song_sheet_url(name):
+    """Builds the public chord-sheet URL for a changelog song entry.
+
+    Songs appear in changes.json as "Title - Artist" strings; the songs site
+    publishes each at /songs/sheets/<slug>/, where the slug is that string
+    lowercased with accents stripped, apostrophes removed, and every run of
+    other non-alphanumeric characters collapsed to a single hyphen — e.g.
+    "Can't Get You Out of My Head - Kylie Minogue" becomes
+    "cant-get-you-out-of-my-head-kylie-minogue".
+
+    Returns None when the name yields an empty slug, so callers can fall back
+    to plain text rather than linking to a broken URL.
+    """
+    # Strip accents (é -> e) and drop any remaining non-ASCII characters.
+    ascii_name = (
+        unicodedata.normalize('NFKD', name)
+        .encode('ascii', 'ignore')
+        .decode('ascii')
+    )
+    # Remove apostrophes outright so "can't" -> "cant", not "can-t".
+    ascii_name = ascii_name.replace("'", '')
+    slug = re.sub(r'[^a-z0-9]+', '-', ascii_name.lower()).strip('-')
+    if not slug:
+        return None
+    return f"{SONGS_SHEET_BASE_URL}/{slug}/"
+
+def _changelog_song(name):
+    """Shapes one changelog song into a display name and its sheet URL (which
+    may be None when no valid slug can be derived)."""
+    return {'name': name, 'url': song_sheet_url(name)}
+
 def _changelog_entry(entry):
     """Shapes one changes.json entry for display: a date plus the song lists
-    added and removed."""
+    added and removed, each song carrying its name and chord-sheet URL."""
     return {
         'date': format_changelog_date(entry.get('generated_at')),
-        'added': entry.get('added', []),
-        'removed': entry.get('removed', []),
+        'added': [_changelog_song(s) for s in entry.get('added', [])],
+        'removed': [_changelog_song(s) for s in entry.get('removed', [])],
     }
 
 def build_changelog(changes, history_limit=CHANGELOG_HISTORY_LIMIT):

--- a/templates/index.html.j2
+++ b/templates/index.html.j2
@@ -45,19 +45,20 @@
     </header>
     
     <main>
+      {% macro changelog_song(song) %}{% if song.url %}<a href="{{ song.url }}" target="_blank" rel="noopener noreferrer">{{ song.name }}</a>{% else %}{{ song.name }}{% endif %}{% endmacro %}
       {% macro changelog_entry(entry) %}
       <div class="changelog-entry">
         {% if entry.date %}<div class="changelog-date">{{ entry.date }}</div>{% endif %}
         {% if entry.added %}
         <div class="changelog-group changelog-added">
           <h4>Added</h4>
-          <ul>{% for song in entry.added %}<li>{{ song }}</li>{% endfor %}</ul>
+          <ul>{% for song in entry.added %}<li>{{ changelog_song(song) }}</li>{% endfor %}</ul>
         </div>
         {% endif %}
         {% if entry.removed %}
         <div class="changelog-group changelog-removed">
           <h4>Removed</h4>
-          <ul>{% for song in entry.removed %}<li>{{ song }}</li>{% endfor %}</ul>
+          <ul>{% for song in entry.removed %}<li>{{ changelog_song(song) }}</li>{% endfor %}</ul>
         </div>
         {% endif %}
       </div>

--- a/test_build.py
+++ b/test_build.py
@@ -10,7 +10,7 @@ import yaml
 from unittest.mock import MagicMock
 
 # Import functions from build.py for testing
-from build import get_buymeacoffee_stats, get_buymeacoffee_subscriptions, render_index, get_editions_config, get_latest_edition_info, get_edition_manifest, create_session_with_retry, get_edition_changes, build_changelog, format_changelog_date
+from build import get_buymeacoffee_stats, get_buymeacoffee_subscriptions, render_index, get_editions_config, get_latest_edition_info, get_edition_manifest, create_session_with_retry, get_edition_changes, build_changelog, format_changelog_date, song_sheet_url
 
 
 @pytest.fixture
@@ -439,6 +439,22 @@ def test_format_changelog_date():
     assert format_changelog_date('not-a-date') == ''
 
 
+def test_song_sheet_url():
+    """Test deriving a song's chord-sheet URL from its "Title - Artist" string."""
+    sheets = 'https://ukuleletuesday.github.io/songs/sheets'
+    # Apostrophes are dropped (not hyphenated) and other punctuation collapses
+    # to single hyphens, matching the songs site's slug convention.
+    assert song_sheet_url("Can't Get You Out of My Head - Kylie Minogue") == \
+        f'{sheets}/cant-get-you-out-of-my-head-kylie-minogue/'
+    # Accents are stripped to their ASCII base.
+    assert song_sheet_url('Crème Brûlée - Béyoncé') == f'{sheets}/creme-brulee-beyonce/'
+    # Curly apostrophes are dropped just like straight ones.
+    assert song_sheet_url('Don’t Stop - Fleetwood Mac') == f'{sheets}/dont-stop-fleetwood-mac/'
+    # A name with no slug-able characters yields None so callers skip linking.
+    assert song_sheet_url('!!!') is None
+    assert song_sheet_url('') is None
+
+
 def test_build_changelog():
     """Test building the 'What's new' panel data from changes.json."""
     changes = {
@@ -462,18 +478,28 @@ def test_build_changelog():
     }
     result = build_changelog(changes)
 
-    # Latest change is shown in full, with a formatted date.
+    sheets = 'https://ukuleletuesday.github.io/songs/sheets'
+
+    # Latest change is shown in full, with a formatted date. Each song carries
+    # its display name and a link to its chord sheet.
     assert result['latest'] == {
         'date': '9 Jun 2026',
-        'added': ['New Song - Artist A', 'Another One - Artist B'],
-        'removed': ['Old Song - Artist C'],
+        'added': [
+            {'name': 'New Song - Artist A', 'url': f'{sheets}/new-song-artist-a/'},
+            {'name': 'Another One - Artist B', 'url': f'{sheets}/another-one-artist-b/'},
+        ],
+        'removed': [
+            {'name': 'Old Song - Artist C', 'url': f'{sheets}/old-song-artist-c/'},
+        ],
     }
 
     # Earlier changes carry the same full shape (date + song lists) as the latest.
     assert result['earlier'] == [
         {
             'date': '2 Jun 2026',
-            'added': ['Hey Jude - The Beatles'],
+            'added': [
+                {'name': 'Hey Jude - The Beatles', 'url': f'{sheets}/hey-jude-the-beatles/'},
+            ],
             'removed': [],
         },
     ]
@@ -513,13 +539,16 @@ def test_render_index_with_changelog(sample_supporter_stats):
         'changelog': {
             'latest': {
                 'date': '9 Jun 2026',
-                'added': ['Brand New Song - The Band'],
-                'removed': ['Retired Song - Old Act'],
+                'added': [{'name': 'Brand New Song - The Band',
+                           'url': 'https://ukuleletuesday.github.io/songs/sheets/brand-new-song-the-band/'}],
+                'removed': [{'name': 'Retired Song - Old Act',
+                             'url': 'https://ukuleletuesday.github.io/songs/sheets/retired-song-old-act/'}],
             },
             'earlier': [
                 {
                     'date': '2 Jun 2026',
-                    'added': ['An Older Addition - Some Artist'],
+                    'added': [{'name': 'An Older Addition - Some Artist',
+                               'url': 'https://ukuleletuesday.github.io/songs/sheets/an-older-addition-some-artist/'}],
                     'removed': [],
                 },
             ],
@@ -535,6 +564,8 @@ def test_render_index_with_changelog(sample_supporter_stats):
     assert 'Removed' in html
     assert 'Brand New Song - The Band' in html
     assert 'Retired Song - Old Act' in html
+    # Songs link to their chord sheets on the songs site.
+    assert 'https://ukuleletuesday.github.io/songs/sheets/brand-new-song-the-band/' in html
     assert '9 Jun 2026' in html
     # Earlier changes are revealed via a button and list their songs in full.
     assert 'changelog-more' in html


### PR DESCRIPTION
## What

Songs listed as **Added** / **Removed** in the "What's new" changelog panel now link to their chord sheet on the songs site, e.g.:

> https://ukuleletuesday.github.io/songs/sheets/cant-get-you-out-of-my-head-kylie-minogue/

## How

- New `song_sheet_url(name)` helper in `build.py` derives a sheet URL from a changelog song's `"Title - Artist"` string. The slug matches the songs site's `/sheets/<title>-<artist>/` convention: lowercased, accents stripped (é → e), apostrophes dropped (`can't` → `cant`), and every run of other non-alphanumeric characters collapsed to a single hyphen.
- Changelog entries now shape each song as `{name, url}` (in `_changelog_entry`), and the template renders a link when a URL is available.
- Songs whose name yields no valid slug (e.g. punctuation-only) get `url = None` and **fall back to plain text** rather than linking to a broken URL.

## Notes / caveats

- The slug algorithm is reverse-engineered from the songs site's documented `/sheets/<title>-<artist>/` convention and the canonical example. It is **not validated against the live site at build time** (no network dependency added), so a song whose upstream slug uses different rules for some edge case could link to a 404. If the songs site ever publishes an index of canonical slugs, we could validate against it.
- Removed songs are linked too; their sheets generally still exist on the songs site even after being dropped from a songbook.

## Tests

- Added `test_song_sheet_url` covering the canonical example, accents, curly apostrophes, and empty/unslug-able names.
- Updated `test_build_changelog` and `test_render_index_with_changelog` for the new `{name, url}` shape and to assert the rendered sheet links.
- Full suite: 37 passed.

https://claude.ai/code/session_01Dg5y281Wef3PktKscHwDE2

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dg5y281Wef3PktKscHwDE2)_