### PR TITLE
Add travel-songbook as first visible edition

### DIFF
--- a/editions.yml
+++ b/editions.yml
@@ -12,6 +12,8 @@
 #   - name: wip
 #     hidden: true         # accessible at /wip/ but not shown on site listing
 editions:
+  - name: travel-songbook
+    hidden: false
   - name: womens-2026
     hidden: true
   - name: wexford-2026


### PR DESCRIPTION
## Summary

Adds the `travel-songbook` edition to `editions.yml` as the **first** entry and makes it **visible** on the site listing (`hidden: false`).

Since `editions.yml` controls both ordering and visibility (visible editions are rendered in the order they appear), placing `travel-songbook` at the top of the list ensures it shows first on the index page.

## Changes
- `editions.yml`: new `travel-songbook` entry at the top with `hidden: false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBfk1pTb7at8GMvqizBgFW)_