### PR TITLE
Publish Pride 2026 edition on the site

### DIFF
--- a/editions.yml
+++ b/editions.yml
@@ -20,6 +20,8 @@ editions:
     hidden: true
   - name: april-fools-2026
     hidden: true
+  - name: pride-2026
+    hidden: false
   - name: current
     hidden: false
   - name: monopolele-2026


### PR DESCRIPTION
## Summary

Adds the **Pride 2026** edition to the songbooks site by registering it in `editions.yml`.

The `pride-2026` songbook PDF is already generated and published to GCS (generated `2026-06-28`, with `latest.json`, `manifest`, and `changes.json` all present in the bucket). However, the site only lists/serves editions that appear in `editions.yml`, so until now the published PDF wasn't reachable from the site. This PR closes that gap.

## Change

```diff
   - name: april-fools-2026
     hidden: true
+  - name: pride-2026
+    hidden: false
   - name: current
     hidden: false
```

- Registered as a **visible** (`hidden: false`) edition, featured for Pride month (June 2026).
- Placed immediately ahead of `current` so the Pride edition leads the visible listing.
- The "What's new" changelog panel will populate automatically from the edition's `changes.json` (present in the bucket).

## Verification

- `editions.yml` parses cleanly and lists `pride-2026`.
- GCS data confirmed live: `pride-2026/latest.json`, `current/latest.json`, and `changes.json` all return `200`.
- Edition-related build tests pass (`pytest test_build.py -k edition` → 6 passed).

## Notes

The generator config (`songbook-generator`) declares `visibility: unlisted` for this edition; this PR intentionally surfaces it as visible on the site for Pride month. Flipping it back to `hidden: true` later is a one-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017kSorsq4EG4ZTGyEUbHAGX

---
_Generated by [Claude Code](https://claude.ai/code/session_017kSorsq4EG4ZTGyEUbHAGX)_